### PR TITLE
Fix bug cannot proxy to HTTP server with port other than default (80)

### DIFF
--- a/src/Straightforward.ts
+++ b/src/Straightforward.ts
@@ -294,7 +294,7 @@ export class Straightforward extends EventEmitter {
     } else {
       const urlParts = new URL(req.url)
       req.locals.urlParts = {
-        host: urlParts.host,
+        host: urlParts.hostname,
         port: parseInt(urlParts.port || "80"),
         path: urlParts.pathname + urlParts.search,
       }


### PR DESCRIPTION
urlParts.host return 'host:port' which causes 'Error: getaddrinfo ENOTFOUND localhost:10309' when calling http.request